### PR TITLE
update to use go 1.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM golang:1.3-cross
+FROM golang:1.4.2-cross
 
 ADD . /go/src/github.com/SvenDowideit/generate_cert
 WORKDIR /go/src/github.com/SvenDowideit/generate_cert


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>